### PR TITLE
Use SHA1 digest with crypto.pbkdf2

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,11 @@ var len = 128;
 var iterations = 12000;
 
 /**
+ * Digest.
+ */
+var digest = 'sha1';
+
+/**
  * Set length to `n`.
  *
  * @param {Number} n
@@ -42,6 +47,18 @@ exports.iterations = function(n){
 };
 
 /**
+ * Set digest to hash algorithm `hash`.
+ *
+ * @param  {String} hash
+ * @api public
+ */
+exports.digest = function(hash) {
+  if (0 === arguments.length) return digest;
+  if( -1 === crypto.getHashes().indexOf(hash)) throw new Error('invalid hash algorithm');
+  digest = hash;
+};
+
+/**
  * Hashes a password with optional `salt`, otherwise
  * generate a salt for `pass` and invoke `fn(err, salt, hash)`.
  *
@@ -55,7 +72,7 @@ exports.hash = function(pwd, salt, fn){
   if (3 == arguments.length) {
     if (!pwd) return fn(new Error('password missing'));
     if (!salt) return fn(new Error('salt missing'));
-    crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
+    crypto.pbkdf2(pwd, salt, iterations, len, digest, function(err, hash){
       if (err) return fn(err);
       fn(null, hash.toString('base64'));
     });
@@ -65,7 +82,7 @@ exports.hash = function(pwd, salt, fn){
     crypto.randomBytes(len, function(err, salt){
       if (err) return fn(err);
       salt = salt.toString('base64');
-      crypto.pbkdf2(pwd, salt, iterations, len, function(err, hash){
+      crypto.pbkdf2(pwd, salt, iterations, len, digest, function(err, hash){
         if (err) return fn(err);
         fn(null, salt, hash.toString('base64'));
       });

--- a/test/pwd.js
+++ b/test/pwd.js
@@ -66,6 +66,31 @@ describe('.iterations(n)', function(){
   })
 })
 
+describe('.digest(hash)', function(){
+  it('should set hash algorithm', function(){
+    pass.digest('sha256');
+    pass.digest().should.equal('sha256');
+  })
+
+  it('should still work', function(done){
+    pass.hash('foobar', function(err, salt, hash){
+      pass.hash('foobar', salt, function(err, cpm){
+        cpm.should.equal(hash);
+        done();
+      })
+    })
+  })
+  describe('when set invalid hash algorithm', function(){
+    it('should throw an error', function(){
+      try {
+        pass.digest('Donald Trump');
+      } catch(e) {
+        e.message.should.include('invalid hash algorithm');
+      }
+    })
+  })
+})
+
 describe('.length(n)', function(){
   it('should set length', function(){
     pass.length(256);


### PR DESCRIPTION
Node v6 has a deprecation warning: "crypto.pbkdf2 without specifying a digest is deprecated"
This pull request add `.digest(hash)` to allow user set a hash algorithm they want. 
The default digest is also set to **SHA1** for backward compatibility with older version.